### PR TITLE
chore: force @actions/http-client's undici to a patched version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,13 +63,13 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@actions/io": {
@@ -1911,9 +1911,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2502,9 +2499,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2522,9 +2516,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2542,9 +2533,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2562,9 +2550,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
   "peerDependencies": {
     "vue": "3.5.40"
   },
+  "overrides": {
+    "@actions/http-client": {
+      "undici": "^7.29.0"
+    }
+  },
   "devDependencies": {
     "semantic-release": "25.0.8",
     "@tailwindcss/vite": "4.3.3",


### PR DESCRIPTION
## Summary
- Adds a scoped override in `package.json` forcing `@actions/http-client`'s `undici` dependency to `^7.29.0`.

`@actions/http-client` (pulled in transitively via `@semantic-release/npm`, used only for OIDC/provenance publishing in the release workflow) pins `undici@^6.23.0`, which resolves to a vulnerable copy. Dependabot's security-update job can't reach that nested copy with a plain `npm update` and fails every run with `Dependabot::NpmAndYarn::FileUpdater::NoChangeError`.

Verified `@actions/http-client`'s GET/HEAD against a real endpoint still work correctly on the overridden `undici@7.29.0` via a local smoke test before opening this PR (this dependency chain only runs during the manual `workflow_dispatch` release job, so there's no way to exercise it through normal CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbJeyq8eRWr2G7eBta5DPm)_