### PR TITLE
ci: drop Node 20 from release test matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ['20', '22', '24', '26']
+        node_version: ['22', '24', '26']
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Node 20 reached end-of-life in April 2026. `build.yml` already dropped it a while back; `release.yml`'s test matrix was left behind still testing against it. Removes it so the release pipeline matches build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgmK6SqXwnQozs7SWxY5fg)_